### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/i18next/i18next-ios.svg)](https://travis-ci.org/i18next/i18next-ios)
 [![Coverage Status](https://coveralls.io/repos/i18next/i18next-ios/badge.svg?service=github)](https://coveralls.io/github/i18next/i18next-ios)
-[![Cocoapods](https://img.shields.io/cocoapods/v/i18next.svg)](https://cocoapods.org/pods/i18next)
+[![CocoaPods](https://img.shields.io/cocoapods/v/i18next.svg)](https://cocoapods.org/pods/i18next)
 [![License](https://img.shields.io/cocoapods/l/i18next.svg)](https://github.com/i18next/i18next-ios/blob/master/LICENSE)
 [![Platform](https://img.shields.io/cocoapods/p/i18next.svg)](https://cocoapods.org/pods/i18next)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
